### PR TITLE
Implement one-off notifications and attachments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build-python:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,100 @@
+name: Publish Package
+
+on:
+  push:
+    tags:
+      - 'v*'  # Triggers on tags like v1.0.0, v2.1.3, etc.
+
+jobs:
+  test-before-publish:
+    name: Run tests before publishing
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry install
+
+      - name: Run tests
+        run: poetry run tox
+        env:
+          OPENAI_API_KEY: "sk-fake-test-key-123"
+
+  # Make sure tests pass before publishing
+  check-tests:
+    name: Check that tests pass
+    runs-on: ubuntu-latest
+    needs: test-before-publish
+    steps:
+      - name: Tests passed
+        run: echo "All tests passed successfully"
+
+  # Publish only after tests pass
+  publish-release:
+    name: Publish release
+    needs: [test-before-publish, check-tests]
+    runs-on: ubuntu-latest
+    if: ${{ needs.test-before-publish.result == 'success' }}
+
+    permissions:
+      contents: write  # Needed to create GitHub releases
+      id-token: write  # Needed for trusted publishing to PyPI
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch full history for proper version detection
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"  # Use a stable Python version for publishing
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: latest
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Cache Poetry dependencies
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: poetry-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Install dependencies
+        run: poetry install --only=main
+
+      - name: Build package
+        run: poetry build
+
+      - name: Verify package contents
+        run: |
+          # List the built packages
+          ls -la dist/
+          # Check package contents
+          poetry run pip install twine
+          poetry run twine check dist/*
+
+      - name: Publish to PyPI
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          poetry config pypi-token.pypi $POETRY_PYPI_TOKEN_PYPI
+          poetry publish

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ tmp_email/
 
 # built files
 dist/
+notifications.json

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This package doesn't implement an actual adapter, but it helps you to make an ex
 To install VintaSend Celery you need to run the following command:
 
 ```shell
-pip install vinstasend vintasend-celery
+pip install vintasend vintasend-celery
 ```
 
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,8 +4,8 @@
 
 ### 🚀 Major Features
 
-* Support to one-off notifications (to non-users)
-* Support to attachments
+* Support for one-off notifications (to non-users)
+* Support for attachments
 
 ## Version 0.1.4 (Initial Release)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,12 @@
+# Release Notes
+
+## Version 1.0.1 (2025-09-16)
+
+### 🚀 Major Features
+
+* Support to one-off notifications (to non-users)
+* Support to attachments
+
+## Version 0.1.4 (Initial Release)
+
+Initial version of VintaSend with core notification functionality.

--- a/example_app/__init__.py
+++ b/example_app/__init__.py
@@ -1,0 +1,1 @@
+# Example app for VintaSend Celery integration

--- a/poetry.lock
+++ b/poetry.lock
@@ -102,7 +102,7 @@ version = "2025.4.26"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3"},
     {file = "certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6"},
@@ -126,7 +126,7 @@ version = "3.4.2"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "charset_normalizer-3.4.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7c48ed483eb946e6c04ccbe02c6b4d1d48e51944b6db70f697e089c193404941"},
     {file = "charset_normalizer-3.4.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2d318c11350e10662026ad0eb71bb51c7812fc8590825304ae0bdd4ac283acd"},
@@ -509,7 +509,7 @@ version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
     {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
@@ -840,19 +840,19 @@ files = [
 
 [[package]]
 name = "requests"
-version = "2.32.3"
+version = "2.32.5"
 description = "Python HTTP for Humans."
 optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
+python-versions = ">=3.9"
+groups = ["main", "dev"]
 files = [
-    {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
-    {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
+    {file = "requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"},
+    {file = "requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"},
 ]
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-charset-normalizer = ">=2,<4"
+charset_normalizer = ">=2,<4"
 idna = ">=2.5,<4"
 urllib3 = ">=1.21.1,<3"
 
@@ -1011,7 +1011,7 @@ version = "2.4.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"},
     {file = "urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466"},
@@ -1037,18 +1037,20 @@ files = [
 
 [[package]]
 name = "vintasend"
-version = "0.1.4"
+version = "1.0.1"
 description = "A flexible package for implementing transactional notifications"
 optional = false
 python-versions = "<3.14,>=3.9"
 groups = ["main"]
 files = [
-    {file = "vintasend-0.1.4-py3-none-any.whl", hash = "sha256:c840a5ffa045d19cf7651b726d60aa25ef21b62c4e0190182bddf2d08ca5870e"},
-    {file = "vintasend-0.1.4.tar.gz", hash = "sha256:7eedd356804941f6ffa5af329b93eace678ba2cff6b865356a8388eb47d435bb"},
+    {file = "vintasend-1.0.1-py3-none-any.whl", hash = "sha256:b409341598bf160cd0aeafea05761eea55c7ecc5401795c7403e98c895049662"},
+    {file = "vintasend-1.0.1.tar.gz", hash = "sha256:df389c11343d91168681bd0c8e8de532c4d65c50efb18371c566f9c0e3c82ba6"},
 ]
 
 [package.dependencies]
+packaging = ">=25.0,<26.0"
 pytest-asyncio = ">=0.24.0,<0.25.0"
+requests = ">=2.32.5,<3.0.0"
 typing-extensions = ">=4.12.2,<5.0.0"
 
 [[package]]
@@ -1087,4 +1089,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "<3.14,>=3.10"
-content-hash = "005d845cd921e5e8b246ab9d3e1b5834e3ec7b69f80ab153623a02bad6ab61e7"
+content-hash = "4454a6e1a820990a9d7e02deb29cc78c5d8f6f8748166a6cd18be6ec1609a514"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "vintasend-celery"
-version = "0.1.4"
+version = "1.0.1"
 description = "Celery adapter for VintaSend"
 authors = ["Hugo bessa <hugo@vinta.com.br>"]
 license = "MIT"
@@ -12,7 +12,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "<3.14,>=3.10"
-vintasend = "0.1.4"
+vintasend = "^1.0.1"
 celery = "^5.4.0"
 
 

--- a/vintasend_celery/tests/test_services/test_adapters.py
+++ b/vintasend_celery/tests/test_services/test_adapters.py
@@ -137,6 +137,41 @@ def test_backend_with_non_serializable_kwargs(renderer, celery_app):
     backend.clear()
 
 
+def test_backend_with_non_serializable_attachment(renderer, celery_app):
+    """Test backend serialization failure with non-serializable attachment."""
+    notification = create_notification()
+    
+    # Create a non-serializable attachment (e.g., a function object)
+    class NonSerializableAttachment:
+        def __init__(self):
+            self.filename = "test.txt"
+            self.content_type = "text/plain"
+            self.description = "Non-serializable attachment"
+            self.is_inline = False
+            # Add a function that can't be serialized
+            self.func = lambda x: x
+
+    non_serializable_attachment = NonSerializableAttachment()
+    notification.attachments = [non_serializable_attachment]
+    
+    from vintasend_celery.services.notification_adapters.celery_adapter_factory import (
+        CeleryNotificationAdapter,
+    )
+
+    class MockAdapter(CeleryNotificationAdapter):
+        def __init__(self):
+            pass
+
+        def serialize_config(self):
+            return {}
+
+    adapter = MockAdapter()
+    
+    with pytest.raises((ValueError, AttributeError, TypeError)):
+        # This should fail because the attachment type is not supported
+        adapter.notification_to_dict(notification)
+
+
 def create_one_off_notification():
     """Create a test one-off notification."""
     register_context("test_context")(create_notification_context)
@@ -157,26 +192,40 @@ def create_one_off_notification():
     )
 
 
-def create_notification_with_attachments():
+def create_notification_with_attachments(attachments=None):
     """Create a test notification with attachments."""
     register_context("test_context")(create_notification_context)
 
-    # Create test attachments
-    attachments = [
-        NotificationAttachment(
-            file=BytesIO(b"test file content"),
-            filename="test.txt",
-            content_type="text/plain",
-            description="Test file"
-        ),
-        NotificationAttachment(
-            file=BytesIO(b"test pdf content"),
-            filename="test.pdf",
-            content_type="application/pdf",
-            is_inline=False,
-            description="Test PDF"
-        )
-    ]
+    if attachments is None:
+        # Create default test attachments
+        attachments = [
+            NotificationAttachment(
+                file=BytesIO(b"test file content"),
+                filename="test.txt",
+                content_type="text/plain",
+                description="Test file"
+            ),
+            NotificationAttachment(
+                file=BytesIO(b"test pdf content"),
+                filename="test.pdf",
+                content_type="application/pdf",
+                is_inline=False,
+                description="Test PDF"
+            )
+        ]
+    elif isinstance(attachments, list) and len(attachments) > 0 and isinstance(attachments[0], dict):
+        # Convert dict format to NotificationAttachment objects
+        attachment_objects = []
+        for att_dict in attachments:
+            attachment_objects.append(
+                NotificationAttachment(
+                    file=BytesIO(att_dict.get("content", b"default content")),
+                    filename=att_dict.get("filename", "default.txt"),
+                    content_type=att_dict.get("content_type", "text/plain"),
+                    description=att_dict.get("description", "Default attachment")
+                )
+            )
+        attachments = attachment_objects
 
     return Notification(
         id=uuid.uuid4(),
@@ -223,6 +272,58 @@ def test_send_one_off_notification(notification_backend, celery_app):
     assert updated_notification.status == NotificationStatus.SENT.value
 
 
+def test_send_one_off_notification_missing_required_fields(notification_backend, celery_app):
+    """Test error handling when required fields are missing."""
+    renderer = FakeTemplateRenderer()
+    async_adapter = AsyncCeleryFakeEmailAdapter(
+        template_renderer=renderer, backend=notification_backend
+    )
+    notification_service = NotificationService([async_adapter], notification_backend)
+
+    # Missing subject_template
+    invalid_notification = create_one_off_notification()
+    invalid_notification.subject_template = None
+
+    # Store the notification first
+    notification_backend.notifications.append(invalid_notification)
+    notification_backend._store_notifications()
+
+    # The system should handle this gracefully (fake renderer doesn't fail on None)
+    notification_service.send(invalid_notification)
+    
+    # Verify it was processed
+    from vintasend.services.notification_backends.stubs.fake_backend import FakeFileBackend
+    fresh_backend = FakeFileBackend(database_file_name="celery-adapter-tests-notifications.json")
+    updated_notification = fresh_backend.get_notification(invalid_notification.id)
+    assert updated_notification.status == NotificationStatus.SENT.value
+
+
+def test_send_one_off_notification_invalid_email(notification_backend, celery_app):
+    """Test error handling when recipient email is invalid."""
+    renderer = FakeTemplateRenderer()
+    async_adapter = AsyncCeleryFakeEmailAdapter(
+        template_renderer=renderer, backend=notification_backend
+    )
+    notification_service = NotificationService([async_adapter], notification_backend)
+
+    invalid_notification = create_one_off_notification()
+    invalid_notification.email_or_phone = "not-an-email"
+
+    # Store the notification first
+    notification_backend.notifications.append(invalid_notification)
+    notification_backend._store_notifications()
+
+    # For this test, we'll just ensure the notification can be processed
+    # The actual email validation would happen in the adapter/backend
+    notification_service.send(invalid_notification)
+    
+    # Verify it was processed (the fake backend doesn't validate email format)
+    from vintasend.services.notification_backends.stubs.fake_backend import FakeFileBackend
+    fresh_backend = FakeFileBackend(database_file_name="celery-adapter-tests-notifications.json")
+    updated_notification = fresh_backend.get_notification(invalid_notification.id)
+    assert updated_notification.status == NotificationStatus.SENT.value
+
+
 def test_send_notification_with_attachments(notification_backend, celery_app):
     """Test sending a notification with attachments through Celery."""
     notification = create_notification_with_attachments()
@@ -244,6 +345,90 @@ def test_send_notification_with_attachments(notification_backend, celery_app):
 
     # Verify the notification was processed by checking the backend state
     # Create a fresh backend instance to get the latest data from file
+    from vintasend.services.notification_backends.stubs.fake_backend import FakeFileBackend
+    fresh_backend = FakeFileBackend(database_file_name="celery-adapter-tests-notifications.json")
+    updated_notification = fresh_backend.get_notification(notification.id)
+    assert updated_notification.status == NotificationStatus.SENT.value
+
+
+def test_send_notification_with_empty_attachments(notification_backend, celery_app):
+    """Test sending a notification with an empty attachment list."""
+    notification = create_notification_with_attachments(attachments=[])
+
+    renderer = FakeTemplateRenderer()
+    async_adapter = AsyncCeleryFakeEmailAdapter(
+        template_renderer=renderer, backend=notification_backend
+    )
+
+    notification_service = NotificationService(
+        [async_adapter],
+        notification_backend,
+    )
+
+    notification_backend.notifications.append(notification)
+    notification_backend._store_notifications()
+
+    notification_service.send(notification)
+
+    from vintasend.services.notification_backends.stubs.fake_backend import FakeFileBackend
+    fresh_backend = FakeFileBackend(database_file_name="celery-adapter-tests-notifications.json")
+    updated_notification = fresh_backend.get_notification(notification.id)
+    assert updated_notification.status == NotificationStatus.SENT.value
+
+
+def test_send_notification_with_unsupported_attachment_type(notification_backend, celery_app):
+    """Test sending a notification with an unsupported file type."""
+    # Assuming .exe is unsupported - the actual validation depends on the backend
+    notification = create_notification_with_attachments(
+        attachments=[{"filename": "malware.exe", "content": b"fake-binary-data", "content_type": "application/octet-stream"}]
+    )
+
+    renderer = FakeTemplateRenderer()
+    async_adapter = AsyncCeleryFakeEmailAdapter(
+        template_renderer=renderer, backend=notification_backend
+    )
+
+    notification_service = NotificationService(
+        [async_adapter],
+        notification_backend,
+    )
+
+    notification_backend.notifications.append(notification)
+    notification_backend._store_notifications()
+
+    # For this fake backend, it should process the notification regardless
+    # Real backends might reject certain file types
+    notification_service.send(notification)
+    
+    from vintasend.services.notification_backends.stubs.fake_backend import FakeFileBackend
+    fresh_backend = FakeFileBackend(database_file_name="celery-adapter-tests-notifications.json")
+    updated_notification = fresh_backend.get_notification(notification.id)
+    # For fake backend, it should succeed
+    assert updated_notification.status == NotificationStatus.SENT.value
+
+
+def test_send_notification_with_large_attachment(notification_backend, celery_app):
+    """Test sending a notification with a very large attachment."""
+    large_content = b"x" * (1024 * 1024)  # 1MB file (reduced from 10MB for test speed)
+    notification = create_notification_with_attachments(
+        attachments=[{"filename": "large_file.pdf", "content": large_content, "content_type": "application/pdf"}]
+    )
+
+    renderer = FakeTemplateRenderer()
+    async_adapter = AsyncCeleryFakeEmailAdapter(
+        template_renderer=renderer, backend=notification_backend
+    )
+
+    notification_service = NotificationService(
+        [async_adapter],
+        notification_backend,
+    )
+
+    notification_backend.notifications.append(notification)
+    notification_backend._store_notifications()
+
+    notification_service.send(notification)
+
     from vintasend.services.notification_backends.stubs.fake_backend import FakeFileBackend
     fresh_backend = FakeFileBackend(database_file_name="celery-adapter-tests-notifications.json")
     updated_notification = fresh_backend.get_notification(notification.id)
@@ -287,6 +472,77 @@ def test_notification_serialization_deserialization():
     assert deserialized.first_name == one_off_notification.first_name
     assert deserialized.last_name == one_off_notification.last_name
     assert deserialized.title == one_off_notification.title
+
+
+def test_notification_serialization_with_corrupted_data():
+    """Test deserializing corrupted or incomplete data."""
+    from vintasend_celery.services.notification_adapters.celery_adapter_factory import (
+        CeleryNotificationAdapter,
+    )
+
+    class MockAdapter(CeleryNotificationAdapter):
+        def __init__(self):
+            pass
+
+        def serialize_config(self):
+            return {}
+
+    adapter = MockAdapter()
+
+    # Test with missing required field
+    corrupted_dict = {
+        "id": "test-id",
+        "_notification_type": "regular",
+        # Missing user_id, title, etc.
+    }
+
+    with pytest.raises(KeyError):
+        adapter.notification_from_dict(corrupted_dict)
+
+    # Test with invalid send_after format
+    corrupted_dict_2 = {
+        "id": "test-id",
+        "user_id": 1,
+        "notification_type": "email",
+        "title": "Test",
+        "body_template": "test.html",
+        "context_name": "test",
+        "context_kwargs": {},
+        "subject_template": "test.txt",
+        "preheader_template": "test.html",
+        "status": "pending",
+        "send_after": "invalid-date-format",  # Invalid ISO format
+        "_notification_type": "regular",
+    }
+
+    with pytest.raises((ValueError, KeyError)):
+        adapter.notification_from_dict(corrupted_dict_2)
+
+    # Test with invalid attachment data
+    corrupted_dict_3 = {
+        "id": "test-id",
+        "user_id": 1,
+        "notification_type": "email",
+        "title": "Test",
+        "body_template": "test.html",
+        "context_name": "test",
+        "context_kwargs": {},
+        "subject_template": "test.txt",
+        "preheader_template": "test.html",
+        "status": "pending",
+        "send_after": None,
+        "_notification_type": "regular",
+        "_attachments": [
+            {
+                "id": "test-attachment",
+                "filename": "test.txt",
+                # Missing required fields like content_type, size, etc.
+            }
+        ]
+    }
+
+    with pytest.raises(KeyError):
+        adapter.notification_from_dict(corrupted_dict_3)
 
 
 def test_notification_with_attachments_serialization():


### PR DESCRIPTION
## Summary by Sourcery

Implement one-off notifications and attachments support in the Celery adapter, enhance serialization/deserialization to handle attachments and new notification types, expand tests for edge cases, bump version to 1.0.1, and update documentation and CI workflows for publishing.

New Features:
- Support one-off notifications (non-user recipients) in Celery adapter
- Add support for notification attachments with serialization and backend retrieval placeholders
- Introduce PlaceholderAttachmentFile to defer file operations to backend

Enhancements:
- Extend notification_to_dict and notification_from_dict to handle attachments, distinguish regular vs one-off notifications, and include adapter_extra_parameters and context_used fields
- Refactor delayed_send to accept OneOffNotification payloads and convert typed dicts for internal processing

Build:
- Bump package version to 1.0.1 and update vintasend dependency

CI:
- Modify CI to trigger on push and add a GitHub Actions workflow for package publishing on tag pushes

Documentation:
- Correct installation command in README and add release notes for version 1.0.1

Tests:
- Remove unused celery_worker fixture and add extensive tests for one-off notifications, attachments, serialization/deserialization, and error scenarios

Chores:
- Add example_app placeholder module